### PR TITLE
Adding MachineAutoscaler for g6.12xlarge (multigpu single node)

### DIFF
--- a/components/configs/autoscaling/overlays/multi-autoscaling-pool/rhoaibu-cluster-dev/kustomization.yaml
+++ b/components/configs/autoscaling/overlays/multi-autoscaling-pool/rhoaibu-cluster-dev/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - machineautoscaler-l40-shared.yaml
   - machineautoscaler-t4-private.yaml
   - machineautoscaler-t4-shared.yaml
+  - machineautoscaler-l40-multi.yaml

--- a/components/configs/autoscaling/overlays/multi-autoscaling-pool/rhoaibu-cluster-dev/machineautoscaler-l40-multi.yaml
+++ b/components/configs/autoscaling/overlays/multi-autoscaling-pool/rhoaibu-cluster-dev/machineautoscaler-l40-multi.yaml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling.openshift.io/v1beta1
+kind: MachineAutoscaler
+metadata:
+  name: worker-gpu-g6.12xlarge-us-west-2a
+  namespace: openshift-machine-api
+spec:
+  maxReplicas: 4
+  minReplicas: 0
+  scaleTargetRef:
+    apiVersion: machine.openshift.io/v1beta1
+    kind: MachineSet
+    name: worker-gpu-g6.12xlarge-us-west-2a


### PR DESCRIPTION
In order to scale up / down the g6.12xlarge (multigpu single node), I'm adding MachineAutoscaler for that instance type in dev