### PR TITLE
upgrade rhoai from 2.22 to 2.25

### DIFF
--- a/components/operators/rhoai-operator/patch-channel.yaml
+++ b/components/operators/rhoai-operator/patch-channel.yaml
@@ -3,4 +3,4 @@
   value: Automatic
 - op: replace
   path: /spec/channel
-  value: stable-2.22
+  value: stable-2.25


### PR DESCRIPTION
Upgrade RHOAI Prod BU cluster from 2.22 to 2.25.
Tested in Dev cluster and worked like a charm 🪄