### PR TITLE
bumping llama4 IS / SR to 2.25 after testing

### DIFF
--- a/components/configs/maas/model-serving/base/llama-4-scout-17b-16e-instruct-quantized-w4a16.yaml
+++ b/components/configs/maas/model-serving/base/llama-4-scout-17b-16e-instruct-quantized-w4a16.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
 metadata:
@@ -10,6 +9,7 @@ metadata:
     opendatahub.io/dashboard: 'true'
 spec:
   predictor:
+    automountServiceAccountToken: false
     maxReplicas: 1
     minReplicas: 1
     model:
@@ -35,7 +35,7 @@ spec:
           cpu: '32'
           memory: 300Gi
           nvidia.com/gpu: '4'
-      runtime: vllm-rhoai-2.21
+      runtime: vllm-rhoai-2.25
       storage:
         key: aws-connection-models
         path: RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16/

--- a/components/configs/maas/model-serving/base/serving-runtimes/rhoai-2.25-vllm-sr.yaml
+++ b/components/configs/maas/model-serving/base/serving-runtimes/rhoai-2.25-vllm-sr.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  annotations:
+    opendatahub.io/accelerator-name: ''
+    opendatahub.io/apiProtocol: REST
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    opendatahub.io/template-display-name: 'vLLM-RHOAI-2.25'
+    opendatahub.io/template-name: vllm-rhoai-2.25
+    openshift.io/display-name: vllm-rhoai-2.25
+  name: vllm-rhoai-2.25
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: '8080'
+  containers:
+    - args:
+        - '--port=8080'
+        - '--model=/mnt/models'
+      command:
+        - python
+        - '-m'
+        - vllm.entrypoints.openai.api_server
+      env:
+        - name: HF_HOME
+          value: /tmp/hf_home
+      image: 'quay.io/modh/vllm:rhoai-2.25-cuda'
+      name: kserve-container
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: vLLM
+  volumes:
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 2Gi
+      name: shm


### PR DESCRIPTION
This PR upgrades the InferenceService and adds the Serving Runtime for RHOAI 2.25. Tested in Dev cluster. 